### PR TITLE
Max size on connection pool set to 2

### DIFF
--- a/scribly/delivery/server.py
+++ b/scribly/delivery/server.py
@@ -29,7 +29,9 @@ app.mount("/static", StaticFiles(directory="static"), name="static")
 
 @app.on_event("startup")
 async def startup():
-    app.state.connection_pool = await asyncpg.create_pool(dsn=DATABASE_URL)
+    app.state.connection_pool = await asyncpg.create_pool(
+        dsn=DATABASE_URL, min_size=2, max_size=2
+    )
 
 
 @app.on_event("shutdown")


### PR DESCRIPTION
Honestly i don't understand connection pools, but i have max 20
connection on my postgres instance and one container on heroku is set
to spin up 4 workers, lol

overkill!!