### PR TITLE
Replace newlines with a space in block content

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "dependencies": {
     "argon2": "^0.25.1",
     "casual": "^1.6.2",
-    "cypress": "3.8.0",
+    "cypress": "^3.8.3",
     "cypress-cucumber-preprocessor": "^1.16.2",
     "cypress-plugin-tab": "^1.0.3",
     "pg": "^7.14.0",

--- a/scribly/delivery/server.py
+++ b/scribly/delivery/server.py
@@ -12,16 +12,14 @@ from starlette.applications import Starlette
 from starlette.middleware.authentication import AuthenticationMiddleware
 from starlette.middleware.sessions import SessionMiddleware
 from starlette.responses import HTMLResponse, RedirectResponse, Response
+from starlette.routing import Route
 from starlette.staticfiles import StaticFiles
 from starlette.templating import Jinja2Templates
-from starlette.routing import Route
 
 from scribly import env, exceptions
 from scribly.definitions import User
-from scribly.delivery.middleware import (
-    ScriblyMiddleware,
-    SessionAuthBackend,
-)
+from scribly.delivery.middleware import ScriblyMiddleware, SessionAuthBackend
+from scribly.jinja_helpers import RemoveNewlines
 from scribly.use_scribly import Scribly
 
 DATABASE_URL = env.DATABASE_URL
@@ -31,6 +29,7 @@ logger = logging.getLogger(__name__)
 
 
 templates = Jinja2Templates(directory="templates")
+templates.env.add_extension(RemoveNewlines)
 
 
 async def startup():

--- a/scribly/emails.py
+++ b/scribly/emails.py
@@ -6,13 +6,16 @@ from premailer import Premailer
 
 from scribly import env
 from scribly.definitions import Email, Story, Turn, User
+from scribly.jinja_helpers import RemoveNewlines
 from scribly.util import read_once
 
 website_url = env.WEBSITE_URL
 premailer = Premailer(
     css_text=read_once("static/style.css"), cssutils_logging_level="CRITICAL"
 )
-jinja_env = Environment(loader=FileSystemLoader("email_templates"))
+jinja_env = Environment(
+    loader=FileSystemLoader("email_templates"), extensions=[RemoveNewlines]
+)
 
 
 def build_added_to_story_emails(story: Story) -> List[Email]:

--- a/scribly/jinja_helpers.py
+++ b/scribly/jinja_helpers.py
@@ -6,7 +6,4 @@ from jinja2.ext import Extension
 
 class RemoveNewlines(Extension):
     def preprocess(self, source: str, name: str, filename: Optional[str] = None) -> str:
-        text_without_newlines = re.sub(r"(?<!>)\n\s+(?!<|\s)", " ", source)
-        return re.sub(
-            r"(?<=>)\n\s+(?!<|\s)|(?<!>)\n\s+(?=<)", "", text_without_newlines
-        )
+        return re.sub(r"(?<!>)\n\s+(?!<|\s)", " ", source)

--- a/scribly/jinja_helpers.py
+++ b/scribly/jinja_helpers.py
@@ -1,0 +1,9 @@
+import re
+from typing import Optional
+
+from jinja2.ext import Extension
+
+
+class RemoveNewlines(Extension):
+    def preprocess(self, source: str, name: str, filename: Optional[str] = None) -> str:
+        return re.sub(r"(?<!>)\n\s+(?!<|\s)", " ", source)

--- a/scribly/jinja_helpers.py
+++ b/scribly/jinja_helpers.py
@@ -6,4 +6,7 @@ from jinja2.ext import Extension
 
 class RemoveNewlines(Extension):
     def preprocess(self, source: str, name: str, filename: Optional[str] = None) -> str:
-        return re.sub(r"(?<!>)\n\s+(?!<|\s)", " ", source)
+        text_without_newlines = re.sub(r"(?<!>)\n\s+(?!<|\s)", " ", source)
+        return re.sub(
+            r"(?<=>)\n\s+(?!<|\s)|(?<!>)\n\s+(?=<)", "", text_without_newlines
+        )

--- a/scribly/jinja_helpers_test.py
+++ b/scribly/jinja_helpers_test.py
@@ -22,4 +22,3 @@ def test_remove_new_lines() -> None:
 </div>
 """
     assert output == expected
-

--- a/scribly/jinja_helpers_test.py
+++ b/scribly/jinja_helpers_test.py
@@ -16,9 +16,7 @@ def test_remove_new_lines() -> None:
 
     expected = """
 <div>
-    <p>
-        this is a paragraph with long text. i'm adding a newline, but i don't want the newline to appear in the rendered output.
-    </p>
+    <p>this is a paragraph with long text. i'm adding a newline, but i don't want the newline to appear in the rendered output.</p>
 </div>
 """
     assert output == expected

--- a/scribly/jinja_helpers_test.py
+++ b/scribly/jinja_helpers_test.py
@@ -1,0 +1,25 @@
+from scribly.jinja_helpers import RemoveNewlines
+
+
+def test_remove_new_lines() -> None:
+    source = """
+<div>
+    <p>
+        this is a paragraph with long text. i'm adding a newline,
+        but i don't want the newline to appear in the rendered output.
+    </p>
+</div>
+"""
+
+    extension = RemoveNewlines(None)
+    output = extension.preprocess(source, name="")
+
+    expected = """
+<div>
+    <p>
+        this is a paragraph with long text. i'm adding a newline, but i don't want the newline to appear in the rendered output.
+    </p>
+</div>
+"""
+    assert output == expected
+

--- a/scribly/jinja_helpers_test.py
+++ b/scribly/jinja_helpers_test.py
@@ -16,7 +16,9 @@ def test_remove_new_lines() -> None:
 
     expected = """
 <div>
-    <p>this is a paragraph with long text. i'm adding a newline, but i don't want the newline to appear in the rendered output.</p>
+    <p>
+        this is a paragraph with long text. i'm adding a newline, but i don't want the newline to appear in the rendered output.
+    </p>
 </div>
 """
     assert output == expected

--- a/yarn.lock
+++ b/yarn.lock
@@ -1861,10 +1861,10 @@ cypress-plugin-tab@^1.0.3:
   dependencies:
     ally.js "^1.4.1"
 
-cypress@3.8.0:
-  version "3.8.0"
-  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.8.0.tgz#7d4cd08f81f9048ee36760cc9ee3b9014f9e84ab"
-  integrity sha512-gtEbqCgKETRc3pQFMsELRgIBNgiQg7vbOWTrCi7WE7bgOwNCaW9PEX8Jb3UN8z/maIp9WwzoFfeySfelYY7nRA==
+cypress@^3.8.3:
+  version "3.8.3"
+  resolved "https://registry.yarnpkg.com/cypress/-/cypress-3.8.3.tgz#e921f5482f1cbe5814891c878f26e704bbffd8f4"
+  integrity sha512-I9L/d+ilTPPA4vq3NC1OPKmw7jJIpMKNdyfR8t1EXYzYCjyqbc59migOm1YSse/VRbISLJ+QGb5k4Y3bz2lkYw==
   dependencies:
     "@cypress/listr-verbose-renderer" "0.4.1"
     "@cypress/xvfb" "1.2.4"
@@ -1877,6 +1877,7 @@ cypress@3.8.0:
     commander "2.15.1"
     common-tags "1.8.0"
     debug "3.2.6"
+    eventemitter2 "4.1.2"
     execa "0.10.0"
     executable "4.1.1"
     extract-zip "1.6.7"
@@ -2157,6 +2158,11 @@ esutils@^2.0.0, esutils@^2.0.2:
   version "2.0.3"
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+
+eventemitter2@4.1.2:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/eventemitter2/-/eventemitter2-4.1.2.tgz#0e1a8477af821a6ef3995b311bf74c23a5247f15"
+  integrity sha1-DhqEd6+CGm7zmVsxG/dMI6UkfxU=
 
 events@^2.0.0:
   version "2.1.0"


### PR DESCRIPTION
I'm used to react where:
```html
<p>
  hey, how's it going?
  want to hang out?
</p>
```

renders as
```html
<p>
  hey, how's it going? want to hang out?
</p>
```

this isn't a major problem as both formats render fine on browser. it's mainly an issue since cypress tester won't find `cy.get("p").contains("hey, how's it going? want to hang out?")` won't match the first markdown.

note that this doesn't process injected content, like `<p>{{ story_turn_with_newlines }}</p>`.

also note that in the future if i ever have a template with css that preserves whitespace, i'd probably have to manually add `{{ "\n " }}` as i would in react.